### PR TITLE
fix: invalidate stale cache and stop marquee on repo/params switch

### DIFF
--- a/src/actions/branch-comparison.ts
+++ b/src/actions/branch-comparison.ts
@@ -176,6 +176,8 @@ export class BranchComparisonAction extends BaseGitHubAction<BranchComparisonSet
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !settings.baseBranch || !settings.headBranch || !globalSettings.githubToken) {

--- a/src/actions/commit-activity.ts
+++ b/src/actions/commit-activity.ts
@@ -202,6 +202,8 @@ export class CommitActivityAction extends BaseGitHubAction<CommitActivitySetting
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/actions/discussions-monitor.ts
+++ b/src/actions/discussions-monitor.ts
@@ -185,6 +185,8 @@ export class DiscussionsMonitorAction extends BaseGitHubAction<DiscussionsMonito
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/actions/issue-counter.ts
+++ b/src/actions/issue-counter.ts
@@ -208,6 +208,8 @@ export class IssueCounterAction extends BaseGitHubAction<IssueCounterSettings> {
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/actions/pr-counter.ts
+++ b/src/actions/pr-counter.ts
@@ -207,6 +207,8 @@ export class PRCounterAction extends BaseGitHubAction<PullRequestCounterSettings
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/actions/pr-review-queue.ts
+++ b/src/actions/pr-review-queue.ts
@@ -168,6 +168,8 @@ export class PRReviewQueueAction extends BaseGitHubAction<PRReviewQueueSettings>
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 		if (!globalSettings.githubToken) {
 			if (ev.action.isKey()) {

--- a/src/actions/projects-board.ts
+++ b/src/actions/projects-board.ts
@@ -169,6 +169,8 @@ export class ProjectsBoardAction extends BaseGitHubAction<ProjectsBoardSettings>
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/actions/release-monitor.ts
+++ b/src/actions/release-monitor.ts
@@ -221,6 +221,8 @@ export class ReleaseMonitorAction extends BaseGitHubAction<ReleaseMonitorSetting
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/actions/repo-stats.ts
+++ b/src/actions/repo-stats.ts
@@ -297,6 +297,8 @@ export class RepoStatsAction extends BaseGitHubAction<RepoStatsSettings> {
 
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {
@@ -323,9 +325,9 @@ export class RepoStatsAction extends BaseGitHubAction<RepoStatsSettings> {
 			await ev.action.setFeedback({ canvas: renderStripLoading() });
 		}
 
-		// Re-subscribe with updated settings
+		// Re-subscribe with updated settings (the coordinator auto-detects
+		// repo/params changes and invalidates stale cache)
 		const intervalSec = settings.refreshInterval ?? DEFAULT_REFRESH_INTERVAL;
-		this.coordinator.unsubscribe(ev.action.id);
 		this.coordinator.subscribe({
 			actionId: ev.action.id,
 			repo: settings.repo!,

--- a/src/actions/workflow-status.ts
+++ b/src/actions/workflow-status.ts
@@ -236,6 +236,8 @@ export class WorkflowStatusAction extends BaseGitHubAction<WorkflowStatusSetting
 		const settings: WorkflowStatusSettings = { ...cached, ...incoming };
 		this.actionSettings.set(ev.action.id, settings);
 
+		this.stopMarquee(ev.action.id);
+
 		if (ev.action.isKey()) {
 			const globalSettings = await streamDeck.settings.getGlobalSettings<GlobalSettings>();
 			if (!settings.repo || !globalSettings.githubToken) {

--- a/src/utils/graphql-query-coordinator.ts
+++ b/src/utils/graphql-query-coordinator.ts
@@ -20,6 +20,16 @@ import type {
 	GraphQLRepoResponse,
 	GraphQLSearchResponse,
 } from "../types";
+
+/** Shallow-compare two FragmentParams objects for value equality. */
+function paramsEqual(a?: FragmentParams, b?: FragmentParams): boolean {
+	if (a === b) return true;
+	if (!a || !b) return a == b;
+	const keysA = Object.keys(a) as (keyof FragmentParams)[];
+	const keysB = Object.keys(b) as (keyof FragmentParams)[];
+	if (keysA.length !== keysB.length) return false;
+	return keysA.every((k) => a[k] === b[k]);
+}
 import { RepoDataCache } from "./repo-data-cache";
 import { buildRepoQuery, buildSearchQuery, isGraphQLFragment } from "./graphql-query-builder";
 import { executeGraphQLQuery } from "./github-graphql";
@@ -49,13 +59,24 @@ export class GraphQLQueryCoordinator {
 
 	/**
 	 * Register an action's data needs.
-	 * Call in onWillAppear.
+	 *
+	 * If the action already has a subscription and the repo or params changed,
+	 * the old subscription is removed (triggering cache cleanup for orphaned
+	 * repos) and the new repo's cached fragments are invalidated so the next
+	 * {@link fetchData} call fetches fresh data instead of returning stale cache.
 	 *
 	 * @param subscription - The action's data subscription.
 	 * @param onSiblingRefresh - Optional callback fired when a sibling action
 	 *   (same repo) force-refreshes. Use to re-render with fresh cached data.
 	 */
 	subscribe(subscription: DataSubscription, onSiblingRefresh?: () => Promise<void>): void {
+		const existing = this.subscriptions.get(subscription.actionId);
+
+		if (existing && (existing.repo !== subscription.repo || !paramsEqual(existing.params, subscription.params))) {
+			this.unsubscribe(subscription.actionId);
+			this.cache.invalidate(subscription.repo, subscription.fragments);
+		}
+
 		this.subscriptions.set(subscription.actionId, subscription);
 		if (onSiblingRefresh) {
 			this.refreshCallbacks.set(subscription.actionId, onSiblingRefresh);

--- a/tests/actions/pr-counter.test.ts
+++ b/tests/actions/pr-counter.test.ts
@@ -456,6 +456,111 @@ describe("PRCounterAction", () => {
 		});
 	});
 
+	// ── Repo switching ─────────────────────────────
+	// Verifies that changing the repo in the Property Inspector results in
+	// the coordinator being re-subscribed with the new repo (the coordinator
+	// handles cache invalidation internally when it detects a repo change).
+
+	describe("repo switching", () => {
+		it("should re-subscribe to coordinator with new repo on settings change", async () => {
+			const mockAction = createMockKeyAction("pr-switch-1");
+
+			Object.defineProperty(action, "actions", {
+				get: () => [mockAction],
+				configurable: true,
+			});
+
+			mockCoordinator.fetchData.mockResolvedValue({ prCount: 17 });
+
+			// Initial appear with repo A
+			await action.onWillAppear?.(
+				createWillAppearEvent(mockAction, { repo: "owner/repo-a", stateFilter: "open" }) as never,
+			);
+
+			vi.clearAllMocks();
+			mockGetGlobalSettings.mockResolvedValue({ githubToken: "ghp_test123" });
+			mockCoordinator.fetchData.mockResolvedValue({ prCount: 5 });
+
+			// User changes to repo B via Property Inspector
+			await action.onDidReceiveSettings?.(
+				createDidReceiveSettingsEvent(mockAction, { repo: "owner/repo-b", stateFilter: "open" }) as never,
+			);
+
+			// Coordinator.subscribe should be called with the new repo.
+			// The coordinator itself detects the repo change and invalidates stale cache.
+			expect(mockCoordinator.subscribe).toHaveBeenCalledWith(
+				expect.objectContaining({ actionId: "pr-switch-1", repo: "owner/repo-b" }),
+				expect.any(Function),
+			);
+		});
+
+		it("should display the NEW repo's PR count after switching repos", async () => {
+			const mockAction = createMockKeyAction("pr-switch-2");
+
+			Object.defineProperty(action, "actions", {
+				get: () => [mockAction],
+				configurable: true,
+			});
+
+			mockCoordinator.fetchData.mockResolvedValue({ prCount: 17 });
+
+			// Initial appear with repo A — count is 17
+			await action.onWillAppear?.(
+				createWillAppearEvent(mockAction, { repo: "owner/repo-a", stateFilter: "open" }) as never,
+			);
+
+			vi.clearAllMocks();
+			mockGetGlobalSettings.mockResolvedValue({ githubToken: "ghp_test123" });
+
+			// After repo switch, coordinator returns fresh data for repo B
+			mockCoordinator.fetchData.mockResolvedValue({ prCount: 5 });
+
+			// User switches to repo B
+			await action.onDidReceiveSettings?.(
+				createDidReceiveSettingsEvent(mockAction, { repo: "owner/repo-b", stateFilter: "open" }) as never,
+			);
+
+			// The button should show repo B's count (5), not repo A's stale count (17)
+			const svg = lastImage(mockAction);
+			expect(svg).toContain("5");
+			expect(svg).not.toContain(">17<");
+		});
+
+		it("should re-subscribe when stateFilter changes on same repo", async () => {
+			const mockAction = createMockKeyAction("pr-switch-3");
+
+			Object.defineProperty(action, "actions", {
+				get: () => [mockAction],
+				configurable: true,
+			});
+
+			mockCoordinator.fetchData.mockResolvedValue({ prCount: 17 });
+
+			// Initial appear with open PRs
+			await action.onWillAppear?.(
+				createWillAppearEvent(mockAction, { repo: "owner/repo", stateFilter: "open" }) as never,
+			);
+
+			vi.clearAllMocks();
+			mockGetGlobalSettings.mockResolvedValue({ githubToken: "ghp_test123" });
+			mockCoordinator.fetchData.mockResolvedValue({ prCount: 42 });
+
+			// User changes to closed PRs
+			await action.onDidReceiveSettings?.(
+				createDidReceiveSettingsEvent(mockAction, { repo: "owner/repo", stateFilter: "closed" }) as never,
+			);
+
+			expect(mockCoordinator.subscribe).toHaveBeenCalledWith(
+				expect.objectContaining({ params: { prState: "closed" } }),
+				expect.any(Function),
+			);
+
+			const svg = lastImage(mockAction);
+			expect(svg).toContain("42");
+			expect(svg).toContain("Closed PRs");
+		});
+	});
+
 	// ── Error handling ──────────────────────────
 
 	describe("error handling", () => {

--- a/tests/actions/repo-stats.test.ts
+++ b/tests/actions/repo-stats.test.ts
@@ -1113,8 +1113,8 @@ describe("RepoStatsAction", () => {
 			});
 			await action.onDidReceiveSettings?.(drsEv as never);
 
-			// Should unsubscribe old and subscribe with new repo
-			expect(mockCoordinatorUnsubscribe).toHaveBeenCalledWith("coord-resub-1");
+			// Should re-subscribe with new repo (coordinator auto-detects the
+			// repo change and handles cache invalidation internally)
 			expect(mockCoordinatorSubscribe).toHaveBeenCalledWith(
 				expect.objectContaining({ repo: "owner/new-repo" }),
 				expect.any(Function),
@@ -1135,8 +1135,8 @@ describe("RepoStatsAction", () => {
 			await action.onWillAppear?.(createWillAppearEvent(mockAction, { repo: "owner/repo", statType: "stars" }) as never);
 			mockCoordinatorUnsubscribe.mockClear();
 
-			// PI clears repo
-			await action.onDidReceiveSettings?.(createDidReceiveSettingsEvent(mockAction, {}) as never);
+			// PI explicitly clears repo
+			await action.onDidReceiveSettings?.(createDidReceiveSettingsEvent(mockAction, { repo: "" }) as never);
 
 			expect(mockCoordinatorUnsubscribe).toHaveBeenCalledWith("coord-unsub-drs");
 		});

--- a/tests/utils/graphql-query-coordinator.test.ts
+++ b/tests/utils/graphql-query-coordinator.test.ts
@@ -235,6 +235,90 @@ describe("GraphQLQueryCoordinator", () => {
 		it("should be safe to unsubscribe unknown actionId", () => {
 			expect(() => coordinator.unsubscribe("nonexistent")).not.toThrow();
 		});
+
+		it("should invalidate cache when re-subscribing with a different repo", async () => {
+			cache.set("owner/repo-a", "prCount", 17, "graphql");
+			cache.set("owner/repo-b", "prCount", 99, "graphql");
+
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-a", fragments: ["prCount"] }));
+
+			// Switch to repo-b — the old cached value for repo-b should be invalidated
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-b", fragments: ["prCount"] }));
+
+			// repo-b's stale cache entry (99) should have been invalidated,
+			// so fetchData should re-fetch rather than returning the stale 99
+			const staleFragments = cache.getStaleFragments("owner/repo-b", ["prCount"], 300);
+			expect(staleFragments).toContain("prCount");
+		});
+
+		it("should clean up orphaned repo cache when re-subscribing to a different repo", () => {
+			cache.set("owner/repo-a", "prCount", 17, "graphql");
+
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-a", fragments: ["prCount"] }));
+			expect(cache.has("owner/repo-a", "prCount")).toBe(true);
+
+			// Switch to repo-b — repo-a has no other subscribers so its cache should be cleaned up
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-b", fragments: ["prCount"] }));
+
+			expect(cache.has("owner/repo-a", "prCount")).toBe(false);
+		});
+
+		it("should invalidate cache when re-subscribing with different params", async () => {
+			cache.set("owner/repo", "prCount", 17, "graphql");
+
+			coordinator.subscribe(baseSub({ actionId: "a1", params: { prState: "open" } }));
+
+			// Switch to closed state — cached prCount was for "open" and should be invalidated
+			coordinator.subscribe(baseSub({ actionId: "a1", params: { prState: "closed" } }));
+
+			const staleFragments = cache.getStaleFragments("owner/repo", ["prCount"], 300);
+			expect(staleFragments).toContain("prCount");
+		});
+
+		it("should NOT invalidate cache when re-subscribing with same repo and params", () => {
+			cache.set("owner/repo", "prCount", 42, "graphql");
+
+			coordinator.subscribe(baseSub({ actionId: "a1", params: { prState: "open" } }));
+			coordinator.subscribe(baseSub({ actionId: "a1", params: { prState: "open" } }));
+
+			// Same repo + same params → no invalidation, cached data stays fresh
+			const entry = cache.get("owner/repo", "prCount", 300);
+			expect(entry).not.toBeNull();
+			expect(entry!.data).toBe(42);
+		});
+
+		it("should preserve other subscribers' cache when switching repos", () => {
+			cache.set("owner/repo-a", "prCount", 17, "graphql");
+			cache.set("owner/repo-a", "issueCount", 5, "graphql");
+
+			// Two actions watching repo-a
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-a", fragments: ["prCount"] }));
+			coordinator.subscribe(baseSub({ actionId: "a2", repo: "owner/repo-a", fragments: ["issueCount"] }));
+
+			// a1 switches to repo-b — repo-a still has a2, so its cache should survive
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-b", fragments: ["prCount"] }));
+
+			expect(cache.has("owner/repo-a", "issueCount")).toBe(true);
+		});
+
+		it("should fetch fresh data after repo switch instead of returning stale cache", async () => {
+			// Pre-populate cache for both repos
+			cache.set("owner/repo-a", "prCount", 17, "graphql");
+			cache.set("owner/repo-b", "prCount", 99, "graphql");
+
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-a", fragments: ["prCount"] }));
+
+			// Switch to repo-b
+			mocks.executeGraphQLQuery.mockResolvedValue({
+				data: { repository: makeRepoNode({ openPRs: { totalCount: 5 } }) },
+			});
+			coordinator.subscribe(baseSub({ actionId: "a1", repo: "owner/repo-b", fragments: ["prCount"] }));
+
+			const result = await coordinator.fetchData("a1", TOKEN);
+
+			// Should return freshly fetched data (5), NOT the stale cached 99
+			expect(result.prCount).toBe(5);
+		});
 	});
 
 	// ── Cache-first behavior ─────────────────────────────────────────────


### PR DESCRIPTION
Fixes #12

## Summary

- **Centralize subscription cleanup in `GraphQLQueryCoordinator.subscribe()`**: when an action re-subscribes with a different repo or `FragmentParams`, automatically unsubscribe the old entry (cleaning up orphaned repo caches) and invalidate the new repo's cached fragments so the next `fetchData()` hits the API instead of returning stale cache. This applies to all current and future actions without requiring per-action workarounds.
- **Stop marquee timer on settings change**: the 500ms marquee animation timer was overwriting the loading spinner with old cached display data. All 10 actions with marquee animations now call `stopMarquee()` at the top of `onDidReceiveSettings()`.
- **Remove redundant manual `unsubscribe` in `repo-stats.ts`**: this was a per-action workaround that is now handled centrally by the coordinator.

## Commits

1. **`fix: invalidate stale cache when action switches repo or params`** — Core coordinator fix + `paramsEqual` helper + 9 new tests
2. **`fix: stop marquee timer on settings change to prevent stale render`** — One-line fix in all 10 marquee-enabled actions

## Test plan

- [x] All 1626 existing tests pass
- [x] 6 new coordinator tests verify cache invalidation, orphan cleanup, and param change detection
- [x] 3 new PR counter tests verify repo-switching renders the correct count
- [x] Manually tested on Stream Deck XL — switching repos shows spinner → new count with no flash of stale data

Made with [Cursor](https://cursor.com)