### PR TITLE
chore(agents): sync agents-template v0.20.0 (backlog hygiene)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Stream Deck GitHub Utilities
 
-<!-- agents-template v0.19.0 -->
+<!-- agents-template v0.20.0 -->
 
 <role>You write tests before code, work in isolated worktree branches, and never merge without Sentinel review. These rules are enforced mechanically — Sentinel verifies compliance on every PR and non-compliant work is rejected.</role>
 
@@ -110,6 +110,8 @@ Sentinel is required for ALL changes — 1-line fix, docs-only, config, dep bump
 | APPROVED | Record Report ID + SHA in merge commit. File new 🟡/🟢 findings as issues (`sentinel:important`, `sentinel:minor`). |
 | CONDITIONAL | File issues for all new 🟡/🟢 — do NOT fix in-PR. Link issues in PR, then merge. |
 | REJECTED | Fix 🔴 blockers; do not independently fix 🟡/🟢. Re-commit, re-invoke. File 🟡/🟢 from final verdict report. Max 5 cycles. |
+
+**Issue hygiene** (when filing 🟡/🟢): give each issue a **validity anchor** — `file:line` + the quoted evidence snippet + reviewed SHA + dimension — and add a `sentinel:security` label for A1/A2 or security-path findings, so a later pass can re-check it. File 🟢 minors as **one digest issue per review** (a standalone 🟢 only on recurrence). Optional, opt-in backlog re-validation that **flags stale candidates but never auto-closes**: [`docs/sentinel/BACKLOG-HYGIENE.md`](./docs/sentinel/BACKLOG-HYGIENE.md).
 
 **Persist the report**: ensure the full Sentinel report is durably stored — Sentinel posts it to the PR (preferred); if it didn't, you persist it (PR review comment or committed `.sentinel/reports/<id>.md`) before merge. The merge commit's Report ID must resolve to that artifact.
 

--- a/docs/SENTINEL.md
+++ b/docs/SENTINEL.md
@@ -169,7 +169,7 @@ Aggregate findings from all Phase 2 sub-agents, then classify using exactly thes
 **Cross-dimension findings:** Findings prefixed `[Cross: Dim X]` from one sub-agent that duplicate a finding from the target dimension → consolidate. If the target dimension missed it → adopt the cross-referenced finding at the target dimension's severity default.
 
 **De-duplication (when known issues provided):** apply severity reclassification before matching.
-- Finding matches an open `sentinel:*` issue (same defect mechanism + fix — cite issue #) → **Known** — in report but excluded from verdict. **🔴 can NEVER be Known.**
+- Finding matches an open `sentinel:*` issue (same defect mechanism + fix — cite issue #) → **Known** — in report but excluded from verdict. **🔴 can NEVER be Known.** A match **more severe or newly reachable** than the open issue is NOT Known — carry it at the higher severity (escalate; never silently downgrade a worse new manifestation to Known).
 - Identical root cause (same mechanism + fix) → consolidate into one finding (cite all locations).
 
 ### Phase 4 — Decision rules

--- a/docs/sentinel/BACKLOG-HYGIENE.md
+++ b/docs/sentinel/BACKLOG-HYGIENE.md
@@ -1,0 +1,114 @@
+# Sentinel — Backlog Hygiene (opt-in)
+
+> Companion to [`../SENTINEL.md`](../SENTINEL.md). **Opt-in.** The Sentinel merge-gate is unchanged and stays
+> read-only; **nothing here runs per-PR**. This doc keeps the **issues Sentinel produces** trustworthy over
+> time — without ever letting automation silently drop a real finding.
+
+## Why this exists
+Sentinel files a GitHub issue for every new 🟡/🟢 finding and **never revisits it**, so issues accrete
+**monotonically by design**. Over months a backlog fills with findings whose code was since changed,
+refactored, incidentally fixed, duplicated, or that never mattered — and a large, untrusted backlog is its
+own failure mode: real findings (including security) hide in the noise.
+
+**The one rule — division of labor:** Sentinel/automation **emits signals**; a **human decides what closes.**
+Staleness is a *signal to re-check*, never proof of resolution. **"Stale" ≠ "resolved."**
+
+## 1. Validity anchor (required in every filed `sentinel:*` issue)
+So any issue can be re-checked cheaply, the orchestrator writes an anchor into the issue body when filing —
+the data already exists in the Sentinel report (Evidence Standard snippet + Reviewed SHA). Each issue body carries:
+
+1. a **human + machine readable anchor** (the HTML comment lets the optional sweep/Action parse it):
+
+   ~~~text
+   **Anchor:** `src/foo.ts:120-128` @ `a1b2c3d` · dim `A1`
+   <!-- sentinel-anchor file="src/foo.ts" sha="a1b2c3d" -->
+   ~~~
+
+2. the **quoted ≤3-line evidence snippet** in a fenced code block (already produced by the finding);
+3. the label **`sentinel:security`** when the finding came from dim-a1/a2 or a security-path 🟡.
+
+Anchors are append-only: if a finding migrates, **re-attest** with the new line (§3) — never rewrite the original SHA.
+
+## 2. Labels (create once per adopter)
+```bash
+gh label create sentinel:security          -c '#b60205' -d 'Security-relevant — never auto-closeable'
+gh label create sentinel:candidate-stale   -c '#fbca04' -d 'Cited code changed since filing — human must verify'
+gh label create sentinel:confirmed-present -c '#0e8a16' -d 'Re-validated: finding still applies at HEAD'
+gh label create sentinel:needs-human       -c '#5319e7' -d 'Ambiguous on re-check — human triage required'
+```
+
+## 3. Re-validation sweep — FLAG, NEVER REAP (opt-in)
+Run on demand or on a schedule — **never per-PR** (a per-issue sweep across a 700-item backlog is absurd
+cost). It reads open `sentinel:*` issues, locates each anchor at current HEAD, and **relabels + comments. It
+does not close.**
+
+**Closure authority is asymmetric — this is the core safety control:**
+
+| Issue class | The sweep may propose… | …but NEVER |
+|---|---|---|
+| `sentinel:security` | `confirmed-present` (update file:line if the sink **migrated**) or `needs-human` | propose closure — *ever* |
+| non-security 🟡/🟢 | closure **only on positive resolution evidence** (a guard / escape / bound / regression test now exists at the sink) | close on **absence**, **age**, or a **moved line** |
+
+- **Migration-aware:** match the vulnerable **pattern/sink**, not the original line number — refactors relocate
+  sinks without fixing them, and a vuln can migrate to another file.
+- **Default on doubt = keep open**, label `sentinel:needs-human`.
+- **Audit trail:** every action posts a comment with the re-check SHA, the current `file:line`, and the specific
+  evidence. Closing stays a **human** action (or an opt-in N-day auto-close window that **excludes**
+  `sentinel:security`) and is always reversible by reopening.
+
+### NEVER
+- Auto-close anything labeled `sentinel:security`.
+- Treat **age**, a **deleted/moved line**, or "couldn't find it" as resolution evidence.
+- Run the sweep inside the merge gate, or grant it write access to source code.
+
+## 4. Inflow discipline (prevention beats cleanup)
+The cheapest backlog item is the one never filed — keep the gate's existing levers tight:
+- File 🟢 minors as **one digest issue per review** (a standalone 🟢 only when the same polish recurs).
+- Honor the **materiality floor** (SENTINEL.md Phase 3): omit findings whose own rationale calls the impact immaterial.
+- 🟡 require a real trigger→mechanism→consequence chain, else they are 🟢.
+
+## 5. Optional example Action (copy in only if you want scheduled flagging)
+A deterministic, **flag-only** first pass: it labels `sentinel:candidate-stale` when an anchored file is gone
+at HEAD. **It never closes and never adjudicates `sentinel:security`** — deeper re-validation (positive
+evidence, cross-file migration) is left to the human/agent §3 sweep. Pin the action to a full SHA.
+
+```yaml
+# .github/workflows/sentinel-backlog-hygiene.yml   (OPTIONAL — adopter opt-in)
+name: Sentinel Backlog Hygiene
+on:
+  schedule: [{ cron: '0 6 * * 1' }]   # weekly, Mondays 06:00 UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  flag-stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Flag candidate-stale (never closes)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          short=$(git rev-parse --short HEAD)
+          gh issue list --state open --limit 1000 --json number,body,labels \
+            --jq '.[] | select(any(.labels[].name; test("^sentinel:(important|minor)$")))
+                       | select(any(.labels[].name; . == "sentinel:candidate-stale") | not)
+                       | "\(.number)\t\(.body | @base64)"' \
+          | while IFS=$'\t' read -r num b64; do
+              file=$(printf '%s' "$b64" | base64 -d | grep -oP '(?<=sentinel-anchor file=")[^"]+' | head -1)
+              [ -n "$file" ] && [ ! -f "$file" ] || continue
+              gh issue edit "$num" --add-label 'sentinel:candidate-stale'
+              gh issue comment "$num" --body \
+                "⚠️ Backlog hygiene: the anchored file \`$file\` no longer exists at HEAD ($short). **This does NOT mean the finding is resolved** — code (and vulnerabilities) migrate. A human must verify before closing."
+            done
+```
+
+> The example checks only **file existence** (the cleanest objective signal). Snippet-level and migration-aware
+> checks belong in the §3 human/agent sweep, which can read the snippet and reason about the sink. Keep it
+> flag-only to preserve the safety guarantees above.
+
+## Relationship to the gate
+Nothing here changes a verdict. The only place backlog state already touches the gate is Phase 3 de-dup
+("Known"): a new finding **more severe or newly reachable** than a matched open issue is **not** Known — it
+escalates. Backlog hygiene keeps that signal honest; it does not relax it.

--- a/docs/sentinel/SEVERITY-RUBRIC.md
+++ b/docs/sentinel/SEVERITY-RUBRIC.md
@@ -51,8 +51,9 @@ regardless of which agent orchestrates. Applied AFTER sub-agent findings aggrega
 - **🟡 → 🟢** when there is no trigger, no reachable mechanism, or an immaterial consequence.
 - **Pre-existing** issue the diff neither introduces nor newly reaches → 🟢 max (never 🔴/🟡).
 - Finding matches an open `sentinel:*` issue (same mechanism + fix) → **Known** (excluded
-  from verdict). 🔴 can **NEVER** be Known.
+  from verdict). 🔴 can **NEVER** be Known. A match **more severe or newly reachable** than the
+  open issue is NOT Known — carry it at the higher severity (escalate).
 
 ## Version
-Rubric **v1** — bound to SENTINEL.md ruleset v1 (agents-template v0.19.0). Bump this version
+Rubric **v1** — bound to SENTINEL.md ruleset v1 (agents-template v0.20.0). Bump this version
 whenever severity semantics change, so verdicts stay reproducible against a pinned rubric.


### PR DESCRIPTION
Propagates **agents-template v0.20.0** — opt-in **issue-backlog hygiene** — into this adopter.

**Provenance / review:** pedrofuentes/agents-template#17 · [Release v0.20.0](https://github.com/pedrofuentes/agents-template/releases/tag/v0.20.0). Verbatim, placeholder-free delta; project customizations preserved.

**Changes**
- **add** `docs/sentinel/BACKLOG-HYGIENE.md` — validity anchor, label vocabulary, opt-in **flag-never-reap** re-validation sweep (security never auto-closeable), optional SHA-pinned example Action.
- `AGENTS.md` §After Sentinel — issue **validity anchor** at filing + 🟢-minor **digest** inflow.
- `docs/SENTINEL.md` Phase 3 + `SEVERITY-RUBRIC.md` — de-dup hardened to compare **exploitability** (a more-severe/newly-reachable match is not "Known").
- bump marker `v0.19.0 → v0.20.0`.

No code changes. Principle: *Sentinel emits self-verifying signals; humans keep closure authority — never auto-close (stale ≠ resolved).*

🤖 Synced with [GitHub Copilot CLI](https://github.com/features/copilot/cli)
