### PR TITLE
chore(sentinel): sync agents-template ruleset to v0.23.0 (mandatory validity anchor)

### DIFF
--- a/.github/workflows/sentinel-backlog-hygiene.yml
+++ b/.github/workflows/sentinel-backlog-hygiene.yml
@@ -1,0 +1,32 @@
+name: Sentinel Backlog Hygiene
+# Opt-in, flag-only re-validation pass (docs/sentinel/BACKLOG-HYGIENE.md §5).
+# Deterministic first pass: labels sentinel:candidate-stale when an anchored file
+# is gone at HEAD. It NEVER closes and NEVER adjudicates sentinel:security —
+# deeper re-validation (positive evidence, cross-file migration) is the human §3 sweep.
+on:
+  schedule: [{ cron: '0 6 * * 1' }]   # weekly, Mondays 06:00 UTC
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  flag-stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Flag candidate-stale (never closes)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          short=$(git rev-parse --short HEAD)
+          gh issue list --state open --limit 1000 --json number,body,labels \
+            --jq '.[] | select(any(.labels[].name; test("^sentinel:(important|minor)$")))
+                       | select(any(.labels[].name; . == "sentinel:candidate-stale") | not)
+                       | "\(.number)\t\(.body | @base64)"' \
+          | while IFS=$'\t' read -r num b64; do
+              file=$(printf '%s' "$b64" | base64 -d | grep -oP '(?<=sentinel-anchor file=")[^"]+' | head -1)
+              [ -n "$file" ] && [ ! -f "$file" ] || continue
+              gh issue edit "$num" --add-label 'sentinel:candidate-stale'
+              gh issue comment "$num" --body \
+                "⚠️ Backlog hygiene: the anchored file \`$file\` no longer exists at HEAD ($short). **This does NOT mean the finding is resolved** — code (and vulnerabilities) migrate. A human must verify before closing."
+            done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Stream Deck GitHub Utilities
 
-<!-- agents-template v0.22.0 -->
+<!-- agents-template v0.23.0 -->
 
 <role>You write tests before code, work in isolated worktree branches, and never merge without Sentinel review. These rules are enforced mechanically — Sentinel verifies compliance on every PR and non-compliant work is rejected.</role>
 
@@ -111,7 +111,7 @@ Sentinel is required for ALL changes — 1-line fix, docs-only, config, dep bump
 | CONDITIONAL | File issues for all new 🟡/🟢 — do NOT fix in-PR. Link issues in PR, then merge. |
 | REJECTED | Fix 🔴 blockers; do not independently fix 🟡/🟢. Re-commit, re-invoke. File 🟡/🟢 from final verdict report. Max 5 cycles. |
 
-**Issue hygiene** (when filing 🟡/🟢): give each issue a **validity anchor** — `file:line` + the quoted evidence snippet + reviewed SHA + dimension — and add a `sentinel:security` label for A1/A2 or security-path findings, so a later pass can re-check it. File 🟢 minors as **one digest issue per review** (a standalone 🟢 only on recurrence). Optional, opt-in backlog re-validation that **flags stale candidates but never auto-closes**: [`docs/sentinel/BACKLOG-HYGIENE.md`](./docs/sentinel/BACKLOG-HYGIENE.md).
+**Issue hygiene** (when filing 🟡/🟢): every filed issue MUST carry the **validity anchor** (SENTINEL.md §Follow-ups) — `file:line` + reviewed SHA + the `<!-- sentinel-anchor … -->` marker + the quoted evidence snippet + dimension — plus a `sentinel:security` label for A1/A2 or security-path findings, so a later pass can re-check it. File 🟢 minors as **one digest issue per review** (a standalone 🟢 only on recurrence). Optional, opt-in backlog re-validation that **flags stale candidates but never auto-closes**: [`docs/sentinel/BACKLOG-HYGIENE.md`](./docs/sentinel/BACKLOG-HYGIENE.md).
 
 **Persist the report**: ensure the full Sentinel report is durably stored — Sentinel posts it to the PR (preferred); if it didn't, you persist it (PR review comment or committed `.sentinel/reports/<id>.md`) before merge. The merge commit's Report ID must resolve to that artifact.
 

--- a/docs/SENTINEL.md
+++ b/docs/SENTINEL.md
@@ -226,6 +226,7 @@ Required action: MERGE | FILE_ISSUES_AND_MERGE | FIX_AND_REINVOKE
 
 ### Follow-ups & Actions
 - Emit ONLY the segment matching the verdict — APPROVED → MERGE: file new 🟡/🟢 as issues (`sentinel:important`, `sentinel:minor`) post-merge · CONDITIONAL → FILE_ISSUES_AND_MERGE: file issues for all new 🟡/🟢, link in PR, then merge · REJECTED → FIX_AND_REINVOKE: fix 🔴 blockers only, re-commit, re-invoke, file 🟡/🟢 from final verdict report.
+- **Every filed 🟡/🟢 issue body MUST carry the validity anchor** (free — the evidence snippet + reviewed SHA are already in this report): (1) an anchor line — **Anchor:** `path:L-L` @ `<reviewed short SHA>` · dim `<X>`; (2) the machine marker on its own line `<!-- sentinel-anchor file="path" sha="<reviewed short SHA>" -->`; (3) the finding's quoted ≤3-line evidence in a fenced block. A dim-A1/A2 or security-path 🟡 finding additionally gets the label `sentinel:security` (never auto-closeable). Its (still opt-in) labels, sweep, and re-validation protocol live in [`sentinel/BACKLOG-HYGIENE.md`](sentinel/BACKLOG-HYGIENE.md).
 - ⚠️ Do NOT fix 🟡/🟢 findings in this PR — file as issues only. Exception: small same-file no-new-risk 🟡 fixes MAY be folded in, but the folded SHA MUST be re-invoked for a fresh verdict before merge (delta re-review applies) — merging on the prior verdict violates SHA-binding.
 
 ### Decision rationale

--- a/docs/sentinel/BACKLOG-HYGIENE.md
+++ b/docs/sentinel/BACKLOG-HYGIENE.md
@@ -1,8 +1,9 @@
-# Sentinel — Backlog Hygiene (opt-in)
+# Sentinel — Backlog Hygiene
 
-> Companion to [`../SENTINEL.md`](../SENTINEL.md). **Opt-in.** The Sentinel merge-gate is unchanged and stays
-> read-only; **nothing here runs per-PR**. This doc keeps the **issues Sentinel produces** trustworthy over
-> time — without ever letting automation silently drop a real finding.
+> Companion to [`../SENTINEL.md`](../SENTINEL.md). The **§1 validity anchor is REQUIRED** by SENTINEL.md
+> §Follow-ups & Actions in every filed issue; the **§2–§5** labels, sweep, and workflow stay **opt-in**. The
+> Sentinel merge-gate is unchanged and stays read-only; **nothing here runs per-PR**. This doc keeps the
+> **issues Sentinel produces** trustworthy over time — without ever letting automation silently drop a real finding.
 
 ## Why this exists
 Sentinel files a GitHub issue for every new 🟡/🟢 finding and **never revisits it**, so issues accrete
@@ -13,9 +14,10 @@ own failure mode: real findings (including security) hide in the noise.
 **The one rule — division of labor:** Sentinel/automation **emits signals**; a **human decides what closes.**
 Staleness is a *signal to re-check*, never proof of resolution. **"Stale" ≠ "resolved."**
 
-## 1. Validity anchor (required in every filed `sentinel:*` issue)
-So any issue can be re-checked cheaply, the orchestrator writes an anchor into the issue body when filing —
-the data already exists in the Sentinel report (Evidence Standard snippet + Reviewed SHA). Each issue body carries:
+## 1. Validity anchor — REQUIRED by SENTINEL.md §Follow-ups (in every filed `sentinel:*` issue)
+[`SENTINEL.md`](../SENTINEL.md) §Follow-ups & Actions **requires** this anchor in every filed issue — it is
+**not** opt-in. So any issue can be re-checked cheaply, the orchestrator writes the anchor into the issue body
+when filing — the data already exists in the Sentinel report (Evidence Standard snippet + Reviewed SHA). Each issue body carries:
 
 1. a **human + machine readable anchor** (the HTML comment lets the optional sweep/Action parse it):
 


### PR DESCRIPTION
## Sync agents-template ruleset → v0.23.0 (mandatory validity anchor)

Vendored-copy sync to [agents-template v0.23.0](https://github.com/pedrofuentes/agents-template/releases/tag/v0.23.0). The one behavioral change upstream: the Sentinel **validity anchor is now mandatory** on every filed 🟡/🟢 issue (previously opt-in backlog hygiene). Filled placeholders are preserved — the vendored copy differs from upstream only by those fills.

### Changed (vendored — verbatim sync)
- **`docs/SENTINEL.md`** §Follow-ups & Actions — mandatory-anchor requirement added (anchor line + `<!-- sentinel-anchor … -->` marker + quoted evidence; `sentinel:security` for A1/A2/security-path).
- **`docs/sentinel/BACKLOG-HYGIENE.md`** §1 — reframed opt-in → **required by SENTINEL.md §Follow-ups**; §2–§5 (labels, sweep, workflow) stay opt-in. No safety rule weakened.
- **`AGENTS.md`** — marker bumped to v0.23.0; §After Sentinel Issue-hygiene line aligned.

### Added
- **`.github/workflows/sentinel-backlog-hygiene.yml`** — opt-in, flag-only weekly pass (BACKLOG-HYGIENE §5). Labels `sentinel:candidate-stale` when an anchored file is gone at HEAD; **never closes**, never adjudicates `sentinel:security`. `actions/checkout` SHA-pinned (v4.2.2).

### Out-of-band (not in this diff)
- Labels `sentinel:security`, `sentinel:candidate-stale`, `sentinel:confirmed-present`, `sentinel:needs-human` created via API (idempotent).
- **Backfill** of existing open `sentinel:*` issues (add validity anchors) is a **separate, human-approved** step — append-only, idempotent, **never closes or relabels-to-resolved**.
